### PR TITLE
Includes OpenSSL version and link to wiki in error

### DIFF
--- a/lemonsync/Connector.py
+++ b/lemonsync/Connector.py
@@ -26,6 +26,7 @@
 #
 # For more information, please refer to <http://unlicense.org/>
 
+import ssl
 import sys
 import time
 import os
@@ -56,11 +57,16 @@ class Connector:
 			'Authorization': 'Bearer ' + api_access
 		}
 
+		sslVERSION = ssl.OPENSSL_VERSION
+
 		try:
 			# The connection will fail if the configuation values are not set correctly
 			r = requests.post(api_host + path, headers=headers, allow_redirects=False, verify=False)
 		except requests.exceptions.RequestException as e:
-			sys.exit(Fore.RED + "Could not make connection to LemonStand. Please verify that your store host configuration is correct." + Style.RESET_ALL + "\n\tDetail: " + str(e))
+			sys.exit(Fore.RED + "Could not make connection to LemonStand. Please verify that your store host configuration is correct."
+				+ Fore.RED + "\nYour Python OpenSSL version: " + Fore.GREEN + sslVERSION
+				+ Fore.RED + "\nPlease see https://github.com/lemonstand/lemonsync/wiki/Upgrading-Python if your version is < 1.0.2h"
+				+ Style.RESET_ALL + "\n\tDetail: " + str(e))
 
 		if r.status_code == 401:
 			sys.exit(Fore.RED + "The API Access Token isn't valid for "+api_host+". Please check that your Access Token is correct and not expired." + Style.RESET_ALL)


### PR DESCRIPTION
@robotpony 

Looks like:
![themes_ _-bash_ _105x49](https://cloud.githubusercontent.com/assets/14319209/16856242/fa7dde9a-49cd-11e6-90bd-873658c6bb9b.png)

I think a good place to start for a fix is here:
https://github.com/kennethreitz/requests/issues/1847
> I think this server refuses connections from clients which announce support for SSLv2
This does not work:
```
$ openssl s_client -connect www.howsmyssl.com:443  -cipher 'ALL'
```
While this works:
```
$ openssl s_client -connect www.howsmyssl.com:443  -cipher 'ALL:!SSLv2'
```

Modifying the **requests** library for python might help fix this: https://github.com/kennethreitz/requests/